### PR TITLE
use 0.6.0-pre as minimum julia version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6-
+julia 0.6.0-pre
 Iterators
 DataFlow
 Juno


### PR DESCRIPTION
since `struct` syntax wouldn't work on early 0.6.0-dev versions,
better to stick with the julia-0.5-compatible versions of the package there