### PR TITLE
Make Flux.onehot accessible in the MNIST example

### DIFF
--- a/examples/MNIST.jl
+++ b/examples/MNIST.jl
@@ -1,5 +1,5 @@
 using Flux, MNIST
-using Flux: accuracy
+using Flux: accuracy, onehot
 
 data = [(trainfeatures(i), onehot(trainlabel(i), 0:9)) for i = 1:60_000]
 train = data[1:50_000]


### PR DESCRIPTION
Alternatively, line 4 could be rewritten to

data = [(trainfeatures(i), Flux.onehot(trainlabel(i), 0:9)) for i = 1:60_000]